### PR TITLE
CFCW-37 | Updating Groups Query by Active and Public

### DIFF
--- a/packages/apollos-church-api/src/data/rock-groups/data-source.js
+++ b/packages/apollos-church-api/src/data/rock-groups/data-source.js
@@ -16,7 +16,7 @@ export default class Group extends RockApolloDataSource {
    */
   getChildrenFromParentId = (id) =>
     this.request()
-      .filter(`ParentGroupId eq ${id}`)
+      .filter(`ParentGroupId eq ${id} and IsPublic and IsActive`)
       .get();
 
   getFromId = (id) => {


### PR DESCRIPTION
Group query requirements include needing to pass both Active and Public as true for the Group to be returned by the Rock Group Query