### PR TITLE
move to a more traditional navigation for content items

### DIFF
--- a/packages/apolloschurchapp/src/content-breakout-feed/index.js
+++ b/packages/apolloschurchapp/src/content-breakout-feed/index.js
@@ -44,7 +44,7 @@ const Subtitle = styled(({ theme }) => ({
   textAlign: 'center',
 }))(Text);
 
-const HeaderContainer = ({ title, content }) => (
+const HeaderContainer = ({ content }) => (
   <Container>
     <H3>{content}</H3>
   </Container>
@@ -101,25 +101,36 @@ class ContentItemFeed extends PureComponent {
             variables={{ itemId }}
             fetchPolicy="cache-and-network"
           >
-            {({ loading, error, data, refetch }) => (
-              <FeedView
-                ListItemComponent={ContentCardConnected}
-                content={get(data, 'node.conferenceGroups', [])}
-                isLoading={loading}
-                error={error}
-                refetch={refetch}
-                onPressItem={this.handleOnPress}
-                ListHeaderComponent={
-                  <View>
-                    <HeaderContainer
-                      title={get(data, 'node.title')}
-                      content={get(data, 'node.htmlContent')}
-                    />
-                    <MyBreakoutsBar />
-                  </View>
-                }
-              />
-            )}
+            {({ loading, error, data, refetch }) => {
+              if (
+                get(data, 'node.title') &&
+                get(data, 'node.title') !==
+                  this.props.navigation.getParam('title')
+              ) {
+                this.props.navigation.setParams({
+                  title: get(data, 'node.title'),
+                });
+              }
+              return (
+                <FeedView
+                  ListItemComponent={ContentCardConnected}
+                  content={get(data, 'node.conferenceGroups', [])}
+                  isLoading={loading}
+                  error={error}
+                  refetch={refetch}
+                  onPressItem={this.handleOnPress}
+                  ListHeaderComponent={
+                    <View>
+                      <HeaderContainer
+                        title={get(data, 'node.title')}
+                        content={get(data, 'node.htmlContent')}
+                      />
+                      <MyBreakoutsBar />
+                    </View>
+                  }
+                />
+              );
+            }}
           </Query>
         </SafeAreaView>
       </BackgroundView>

--- a/packages/apolloschurchapp/src/content-breakout-feed/index.js
+++ b/packages/apolloschurchapp/src/content-breakout-feed/index.js
@@ -10,6 +10,7 @@ import {
   BackgroundView,
   FeedView,
   H1,
+  H3,
   H4,
   styled,
 } from '@apollosproject/ui-kit';
@@ -17,7 +18,7 @@ import {
 import ContentCardConnected from 'apolloschurchapp/src/ui/ContentCardConnected';
 import { MyBreakoutsBar } from '../my-breakouts-bar';
 
-import NavigationHeader from '../content-single/NavigationHeader';
+// import NavigationHeader from '../content-single/NavigationHeader';
 import getContentFeed from './getContentFeed';
 
 /**
@@ -26,27 +27,40 @@ import getContentFeed from './getContentFeed';
  */
 const Container = styled(({ theme }) => ({
   marginHorizontal: theme.sizing.baseUnit,
-  marginTop: theme.sizing.baseUnit * 2,
   marginBottom: theme.sizing.baseUnit,
 
-  paddingTop: theme.sizing.baseUnit * 1.7,
-  paddingBottom: theme.sizing.baseUnit * 2,
+  paddingTop: theme.sizing.baseUnit * 1.5,
+  paddingBottom: theme.sizing.baseUnit * 1.5,
 
   borderBottomColor: theme.colors.lightSecondary,
   borderBottomWidth: 1,
+
+  flex: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
 }))(View);
+
+const Subtitle = styled(({ theme }) => ({
+  textAlign: 'center',
+}))(Text);
 
 const HeaderContainer = ({ title, content }) => (
   <Container>
-    <H1>{title}</H1>
-    <H4>{content}</H4>
+    <H3>{content}</H3>
   </Container>
 );
 
 class ContentItemFeed extends PureComponent {
   /** Function for React Navigation to set information in the header. */
-  static navigationOptions = {
-    header: NavigationHeader,
+  // static navigationOptions = {
+  //   header: NavigationHeader,
+  // };
+
+  static navigationOptions = ({ navigation }) => {
+    const title = get(navigation, 'state.params.title');
+    return {
+      headerTitle: title || null,
+    };
   };
 
   static propTypes = {

--- a/packages/apolloschurchapp/src/content-item-feed/index.js
+++ b/packages/apolloschurchapp/src/content-item-feed/index.js
@@ -3,8 +3,6 @@ import { Query } from 'react-apollo';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 
-import SafeAreaView from 'react-native-safe-area-view';
-
 import { BackgroundView, FeedView } from '@apollosproject/ui-kit';
 
 import ContentCardConnected from 'apolloschurchapp/src/ui/ContentCardConnected';
@@ -43,7 +41,7 @@ class ContentItemFeed extends PureComponent {
   /** Function that is called when a card in the feed is pressed.
    * Takes the user to the ContentSingle
    */
-  handleOnPress = (item) => {
+  handleOnPress = item => {
     if (
       item.__typename === 'ConferenceScheduleContentItem' &&
       item.conferenceGroups &&
@@ -79,7 +77,7 @@ class ContentItemFeed extends PureComponent {
                 data,
                 'node.childContentItemsConnection.edges',
                 []
-              ).map((edge) => edge.node)}
+              ).map(edge => edge.node)}
               isLoading={loading}
               error={error}
               refetch={refetch}

--- a/packages/apolloschurchapp/src/content-single/ContentSingle.js
+++ b/packages/apolloschurchapp/src/content-single/ContentSingle.js
@@ -13,7 +13,7 @@ import getContentItem from './getContentItem';
 import DevotionalContentItem from './DevotionalContentItem';
 import UniversalContentItem from './UniversalContentItem';
 
-import NavigationHeader from './NavigationHeader';
+// import NavigationHeader from './NavigationHeader';
 
 class ContentSingle extends PureComponent {
   static propTypes = {
@@ -23,8 +23,11 @@ class ContentSingle extends PureComponent {
     }),
   };
 
-  static navigationOptions = {
-    header: NavigationHeader,
+  static navigationOptions = ({ navigation }) => {
+    const title = get(navigation, 'state.params.title');
+    return {
+      headerTitle: title || null,
+    };
   };
 
   get itemId() {
@@ -58,6 +61,7 @@ class ContentSingle extends PureComponent {
             content={content}
             loading={loading}
             error={error}
+            navigation={this.props.navigation}
           />
         );
     }

--- a/packages/apolloschurchapp/src/content-single/UniversalContentItem/index.js
+++ b/packages/apolloschurchapp/src/content-single/UniversalContentItem/index.js
@@ -15,8 +15,10 @@ import HorizontalContentFeed from '../HorizontalContentFeed';
 
 const FlexedScrollView = styled({ flex: 1 })(ScrollView);
 
-const UniversalContentItem = ({ content, loading }) => {
+const UniversalContentItem = ({ content, loading, navigation }) => {
   const coverImageSources = get(content, 'coverImage.sources', []);
+  if (content.title && navigation.state.params.title !== content.title)
+    navigation.setParams({ title: content.title });
   return (
     <FlexedScrollView>
       {coverImageSources.length || loading ? (

--- a/packages/apolloschurchapp/src/content-single/index.js
+++ b/packages/apolloschurchapp/src/content-single/index.js
@@ -8,8 +8,8 @@ const ContentSingleNavigator = createStackNavigator(
   },
   {
     initialRouteName: 'ContentSingle',
-    headerMode: 'float',
-    headerTransitionPreset: 'fade-in-place',
+    // headerMode: 'float',
+    // headerTransitionPreset: 'fade-in-place',
   }
 );
 

--- a/packages/apolloschurchapp/src/index.js
+++ b/packages/apolloschurchapp/src/index.js
@@ -37,8 +37,8 @@ const AppNavigator = createStackNavigator(
   },
   {
     initialRouteName: 'Tabs',
-    mode: 'modal',
-    headerMode: 'screen',
+    // mode: 'modal',
+    // headerMode: 'screen',
   }
 );
 


### PR DESCRIPTION
This creates traditional nav headers for content items and removes the goofy close/back button thing that was going on:


![screen shot 2019-01-25 at 3 35 59 pm](https://user-images.githubusercontent.com/103927/51774176-ef27a400-20b6-11e9-845f-76abce0946b0.png)

![screen shot 2019-01-25 at 3 36 19 pm](https://user-images.githubusercontent.com/103927/51774186-fb136600-20b6-11e9-8c42-a25a3f5dc866.png)

![screen shot 2019-01-25 at 3 36 35 pm](https://user-images.githubusercontent.com/103927/51774198-02d30a80-20b7-11e9-8a6b-130565003228.png)

This removes some of the flashes and such taht aws happening before on the test flight app